### PR TITLE
Fix circular imports in FairseqModel

### DIFF
--- a/fairseq/models/fairseq_model.py
+++ b/fairseq/models/fairseq_model.py
@@ -13,7 +13,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from fairseq import utils
-from fairseq.checkpoint_utils import prune_state_dict
 from fairseq.data import Dictionary
 from fairseq.models import FairseqDecoder, FairseqEncoder
 from torch import Tensor
@@ -89,6 +88,7 @@ class BaseFairseqModel(nn.Module):
         this additionally "upgrades" *state_dicts* from old checkpoints.
         """
         self.upgrade_state_dict(state_dict)
+        from fairseq.checkpoint_utils import prune_state_dict
         new_state_dict = prune_state_dict(state_dict, args)
         return super().load_state_dict(new_state_dict, strict)
 
@@ -432,6 +432,7 @@ class FairseqMultiModel(BaseFairseqModel):
         this additionally "upgrades" *state_dicts* from old checkpoints.
         """
         self.upgrade_state_dict(state_dict)
+        from fairseq.checkpoint_utils import prune_state_dict
         new_state_dict = prune_state_dict(state_dict, args)
         return super().load_state_dict(new_state_dict, strict)
 


### PR DESCRIPTION
This PR fixes circular imports of `prune_state_dict` in the FairseqModel class (following verbatim from [this PR](https://github.com/facebookresearch/fairseq/pull/3286) in the original fairseq repo). Currently, distributed training on multiple GPUs may result in the following error when importing fairseq:

```
...
File "/home1/jh_445/mega/fairseq/models/__init__.py", line 14, in <module>
  from .fairseq_model import (
 File "/home1/jh_445/mega/fairseq/models/fairseq_model.py", line 16, in <module>
  from fairseq.checkpoint_utils import prune_state_dict
ImportError: cannot import name 'prune_state_dict' from partially initialized module 'fairseq.checkpoint_utils' (most likely due to a circular import) (/home1/jh_445/mega/fairseq/checkpoint_utils.py)
```
The solution is to remove the line `from fairseq.checkpoint_utils import prune_state_dict` as a main import, and only invoke it prior to using `prune_state_dict`. 
